### PR TITLE
pull-request: Hide Signed-off-by

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -252,6 +252,9 @@ of text is the title and the rest is the description.`, fullBase, fullHead))
 		if len(commits) == 1 {
 			message, err = git.Show(commits[0])
 			utils.Check(err)
+
+			re := regexp.MustCompile(`(?m)\n^Signed-off-by:\s.*$`)
+			message = re.ReplaceAllString(message, "")
 		} else if len(commits) > 1 {
 			commitLogs, err = git.Log(baseTracking, headForMessage)
 			utils.Check(err)


### PR DESCRIPTION
Fixes #1724.

This patch omits the "Signed-off-by:" line coming from pull requests created
out of single commit messages. This way the user does not need to manually
remove their email address from the PR description.

Not introducing a flag for this as it applies to only one case (single-commit
diff between heads, as well as no -m/-f/-i specified).

Meta: sending this PR with the patched build, my Signed-off-by line is removed
automatically from the PR message.